### PR TITLE
Update angular-js-bundle dependency version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "php" : ">=5.3.0",
         "claroline/kernel-bundle" : "~1.0",
         "claroline/core-bundle" : "~4.0",
-        "innova/angular-js-bundle" : "1.*"
+        "innova/angular-js-bundle" : "~2.0"
     },
     "autoload" : {
         "psr-0" : {


### PR DESCRIPTION
Without this modification we cannot update platform with core-bundle in 4.5.1 version.
This version of the core require `innova/angular-js-bundle` in 2.\* version.
